### PR TITLE
remove equivocal sentence

### DIFF
--- a/ImplementationGuide/markdown/AkteureUndInteraktionen-Akteure.md
+++ b/ImplementationGuide/markdown/AkteureUndInteraktionen-Akteure.md
@@ -2,7 +2,6 @@
 ### Dokumentenserver
 Das bestätigungsrelevante System nimmt die Rolle des Dokumentenservers ein. Ein Dokumentenserver nimmt Dokumente von Clients zur Speicherung/Archivierung/Verwaltung entgegen und erlaubt Clients die Suche nach und den Abruf von Dokumenten.
 Dieses ISiK-Modul legt fest, welche Suchkriterien mindestens implementiert werden müssen und welche Kriterien darüber hinaus optional bereitgestellt werden können.
-Dokumentenserver müssen mindestens die Interaktion "Dokumentenabfrage" implementieren.
 Um Clients die Herstellung von Patienten- und Encounterkontext zu ermöglichen, müssen weiterhin die im Basismodul Stufe 2 festgelegten Interaktionen auf den Datenobjekten ["Patient"](https://simplifier.net/guide/implementierungsleitfadenisik-basismodul/ImplementationGuide-markdown-Datenobjekte-Datenobjekte-Patient?version=current#ImplementationGuide-markdown-Patient-Patient-Interaktionen) und ["Kontakt/Fall (Encounter)"](https://simplifier.net/guide/implementierungsleitfadenisik-basismodul/ImplementationGuide-markdown-Datenobjekte-Datenobjekte-Patient?version=current#ImplementationGuide-markdown-Patient-Patient-Interaktionen) implementiert werden.
 
 Der Dokumentenserver nimmt im IHE-MHD-Kontext die Rollen [Document Recipient](https://profiles.ihe.net/ITI/MHD/1331_actors_and_transactions.html#133113-document-recipient) und [Document Responder](https://profiles.ihe.net/ITI/MHD/1331_actors_and_transactions.html#133114-document-responder) ein und implementiert die IHE-MHD-Interaktionen

--- a/ImplementationGuide/markdown/AkteureUndInteraktionen-Akteure.md
+++ b/ImplementationGuide/markdown/AkteureUndInteraktionen-Akteure.md
@@ -2,7 +2,7 @@
 ### Dokumentenserver
 Das bestätigungsrelevante System nimmt die Rolle des Dokumentenservers ein. Ein Dokumentenserver nimmt Dokumente von Clients zur Speicherung/Archivierung/Verwaltung entgegen und erlaubt Clients die Suche nach und den Abruf von Dokumenten.
 Dieses ISiK-Modul legt fest, welche Suchkriterien mindestens implementiert werden müssen und welche Kriterien darüber hinaus optional bereitgestellt werden können.
-Dokumentenserver müssen mindestens die Interaktion "Dokumentenabfrage" implementieren. Die Umsetzung der Dokumentenbereitstellung ist optional.
+Dokumentenserver müssen mindestens die Interaktion "Dokumentenabfrage" implementieren.
 Um Clients die Herstellung von Patienten- und Encounterkontext zu ermöglichen, müssen weiterhin die im Basismodul Stufe 2 festgelegten Interaktionen auf den Datenobjekten ["Patient"](https://simplifier.net/guide/implementierungsleitfadenisik-basismodul/ImplementationGuide-markdown-Datenobjekte-Datenobjekte-Patient?version=current#ImplementationGuide-markdown-Patient-Patient-Interaktionen) und ["Kontakt/Fall (Encounter)"](https://simplifier.net/guide/implementierungsleitfadenisik-basismodul/ImplementationGuide-markdown-Datenobjekte-Datenobjekte-Patient?version=current#ImplementationGuide-markdown-Patient-Patient-Interaktionen) implementiert werden.
 
 Der Dokumentenserver nimmt im IHE-MHD-Kontext die Rollen [Document Recipient](https://profiles.ihe.net/ITI/MHD/1331_actors_and_transactions.html#133113-document-recipient) und [Document Responder](https://profiles.ihe.net/ITI/MHD/1331_actors_and_transactions.html#133114-document-responder) ein und implementiert die IHE-MHD-Interaktionen


### PR DESCRIPTION
Der Satz klingt widersprüchlich, ist verwirrend und sollte daher entfernt werden.