### PR TITLE
Add de.ihe-d.terminology dependency

### DIFF
--- a/Resources/sushi-config.yaml
+++ b/Resources/sushi-config.yaml
@@ -6,6 +6,7 @@ canonical: https://gematik.de/fhir/isik/v4/Dokumentenaustausch
 fhirVersion: 4.0.1
 dependencies:
     ihe.iti.mhd: 4.2.0
-    de.gematik.isik-basismodul: 3.0.3
+    de.gematik.isik-basismodul: 4.0.0-rc
+    de.ihe-d.terminology: 3.0.0
     dvmd.kdl.r4.2022: 2022.1.2
 FSHOnly: true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   ],
   "dependencies": {
     "ihe.iti.mhd": "4.2.0",
-    "de.gematik.isik-basismodul": "3.0.3",
+    "de.gematik.isik-basismodul": "4.0.0-rc",
+    "de.ihe-d.terminology": "3.0.0",
     "dvmd.kdl.r4.2022": "2022.1.2"
   }
 }


### PR DESCRIPTION
de.ihe-d.terminology enthält in der Version 3.0.0 expandierbare ValueSets inkl. CodeSystem-Definitionen.