### PR TITLE
add system for Slice XDS

### DIFF
--- a/ImplementationGuide/markdown/ReleaseNotes.md
+++ b/ImplementationGuide/markdown/ReleaseNotes.md
@@ -12,6 +12,7 @@ Datum: 30.04.2024
 
 * fix IHEXDStypeCode Canonical-URL https://github.com/gematik/spec-ISiK-Dokumentenaustausch/pull/187/commits/33b3832adfd65ba6496d419c92870d6f30d4ffe1
 * Add dependency to IHE package
+* Fix der XDS Slices für .type und Category https://github.com/gematik/spec-ISiK-Dokumentenaustausch/pull/189
 * Update Basismodul-Dependency to Patch-Wildcard 3.0.x
 
 ----

--- a/ImplementationGuide/markdown/ReleaseNotes.md
+++ b/ImplementationGuide/markdown/ReleaseNotes.md
@@ -12,7 +12,7 @@ Datum: 30.04.2024
 
 * fix IHEXDStypeCode Canonical-URL https://github.com/gematik/spec-ISiK-Dokumentenaustausch/pull/187/commits/33b3832adfd65ba6496d419c92870d6f30d4ffe1
 * Add dependency to IHE package
-* Fix der XDS Slices für .type und Category https://github.com/gematik/spec-ISiK-Dokumentenaustausch/pull/189
+* Fix der XDS Slices für .type und .category https://github.com/gematik/spec-ISiK-Dokumentenaustausch/pull/189
 * Update Basismodul-Dependency to Patch-Wildcard 3.0.x
 
 ----

--- a/Resources/fsh-generated/resources/Bundle-Suchergebnis-Beispiel.json
+++ b/Resources/fsh-generated/resources/Bundle-Suchergebnis-Beispiel.json
@@ -37,24 +37,24 @@
               "display": "Molekularpathologiebefund"
             },
             {
-              "code": "PATH",
               "system": "http://ihe-d.de/CodeSystems/IHEXDStypeCode",
+              "code": "PATH",
               "display": "Pathologiebefundberichte"
             }
           ]
         },
-        "status": "current",
         "category": [
           {
             "coding": [
               {
-                "code": "BEF",
                 "system": "http://ihe-d.de/CodeSystems/IHEXDSclassCode",
+                "code": "BEF",
                 "display": "Befundbericht"
               }
             ]
           }
         ],
+        "status": "current",
         "description": "Molekularpathologiebefund vom 31.12.21",
         "subject": {
           "reference": "Patient/PatientinMusterfrau"

--- a/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-server.json
+++ b/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-server.json
@@ -24,24 +24,24 @@
         "display": "Molekularpathologiebefund"
       },
       {
-        "code": "PATH",
         "system": "http://ihe-d.de/CodeSystems/IHEXDStypeCode",
+        "code": "PATH",
         "display": "Pathologiebefundberichte"
       }
     ]
   },
-  "status": "current",
   "category": [
     {
       "coding": [
         {
-          "code": "BEF",
           "system": "http://ihe-d.de/CodeSystems/IHEXDSclassCode",
+          "code": "BEF",
           "display": "Befundbericht"
         }
       ]
     }
   ],
+  "status": "current",
   "description": "Molekularpathologiebefund vom 31.12.21",
   "subject": {
     "reference": "Patient/PatientinMusterfrau"

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
@@ -180,6 +180,14 @@
         ]
       },
       {
+        "id": "DocumentReference.type.coding:XDS.system",
+        "path": "DocumentReference.type.coding.system",
+        "short": "Kodiersystem",
+        "min": 1,
+        "patternUri": "http://ihe-d.de/CodeSystems/IHEXDStypeCode",
+        "mustSupport": true
+      },
+      {
         "id": "DocumentReference.category",
         "path": "DocumentReference.category",
         "short": "Dokumentklasse/-Kategorie",
@@ -225,6 +233,7 @@
         "path": "DocumentReference.category.coding.system",
         "short": "Kodiersystem",
         "min": 1,
+        "patternUri": "http://ihe-d.de/CodeSystems/IHEXDStypeCode",
         "mustSupport": true
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
@@ -188,6 +188,22 @@
         "mustSupport": true
       },
       {
+        "id": "DocumentReference.type.coding:XDS.code",
+        "path": "DocumentReference.type.coding.code",
+        "short": "Code",
+        "comment": "Der KDL-Code",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "DocumentReference.type.coding:XDS.display",
+        "path": "DocumentReference.type.coding.display",
+        "short": "Anzeigetext",
+        "comment": "Der Anzeigetext zum KDL-Code",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
         "id": "DocumentReference.category",
         "path": "DocumentReference.category",
         "short": "Dokumentklasse/-Kategorie",
@@ -233,7 +249,7 @@
         "path": "DocumentReference.category.coding.system",
         "short": "Kodiersystem",
         "min": 1,
-        "patternUri": "http://ihe-d.de/CodeSystems/IHEXDStypeCode",
+        "patternUri": "http://ihe-d.de/CodeSystems/IHEXDSclassCode",
         "mustSupport": true
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
@@ -191,7 +191,7 @@
         "id": "DocumentReference.type.coding:XDS.code",
         "path": "DocumentReference.type.coding.code",
         "short": "Code",
-        "comment": "Der KDL-Code",
+        "comment": "Der XDS-Type-Code",
         "min": 1,
         "mustSupport": true
       },
@@ -199,7 +199,7 @@
         "id": "DocumentReference.type.coding:XDS.display",
         "path": "DocumentReference.type.coding.display",
         "short": "Anzeigetext",
-        "comment": "Der Anzeigetext zum KDL-Code",
+        "comment": "Der Anzeigetext zum XDS-Type-Code",
         "min": 1,
         "mustSupport": true
       },

--- a/Resources/input/fsh/ISiKDokumentenMetadaten.fsh
+++ b/Resources/input/fsh/ISiKDokumentenMetadaten.fsh
@@ -51,10 +51,10 @@ In MHD 4.2.0 wurde die Verpflichtung zur Angabe eines Identifiers gelockert, das
   [ConceptMaps](https://simplifier.net/kdl/~resources?category=ConceptMap) aus dem KDL-Code ermittelt werden"
   * code 1..1 MS
     * ^short = "Code"
-    * ^comment = "Der XDS-Code"
+    * ^comment = "Der XDS-Type-Code"
   * display 1..1 MS
     * ^short = "Anzeigetext"
-    * ^comment = "Der Anzeigetext zum XDS-Code"
+    * ^comment = "Der Anzeigetext zum XDS-Type-Code"
 * type.coding[KDL] from http://dvmd.de/fhir/ValueSet/kdl (required)
   * ^short = "Dokumenttyp gem. KDL-Terminologie"
   * system 1..1 MS

--- a/Resources/input/fsh/ISiKDokumentenMetadaten.fsh
+++ b/Resources/input/fsh/ISiKDokumentenMetadaten.fsh
@@ -51,10 +51,10 @@ In MHD 4.2.0 wurde die Verpflichtung zur Angabe eines Identifiers gelockert, das
   [ConceptMaps](https://simplifier.net/kdl/~resources?category=ConceptMap) aus dem KDL-Code ermittelt werden"
   * code 1..1 MS
     * ^short = "Code"
-    * ^comment = "Der KDL-Code"
+    * ^comment = "Der XDS-Code"
   * display 1..1 MS
     * ^short = "Anzeigetext"
-    * ^comment = "Der Anzeigetext zum KDL-Code"
+    * ^comment = "Der Anzeigetext zum XDS-Code"
 * type.coding[KDL] from http://dvmd.de/fhir/ValueSet/kdl (required)
   * ^short = "Dokumenttyp gem. KDL-Terminologie"
   * system 1..1 MS

--- a/Resources/input/fsh/ISiKDokumentenMetadaten.fsh
+++ b/Resources/input/fsh/ISiKDokumentenMetadaten.fsh
@@ -43,6 +43,9 @@ In MHD 4.2.0 wurde die Verpflichtung zur Angabe eines Identifiers gelockert, das
 * type.coding contains  KDL 1..1 MS and XDS 0..1 MS
 * type.coding[XDS] from http://ihe-d.de/ValueSets/IHEXDStypeCode (required)
   * ^short = "Dokumenttyp gem. IHE-De-Terminologie"
+  * system 1..1 MS
+  * system = "http://ihe-d.de/CodeSystems/IHEXDStypeCode"
+    * ^short = "Kodiersystem"
   * ^comment = "Die Übermittlung des XDS-Type-Codes ist im Rahmen der Dokumentenbereitstellung für Clients nicht verpflichtend,
   MUSS jedoch vom Server bei der Entgegennahme ggf. ergänzt und bei der Dokumentenabfrage zurückgegeben werden. Der XDS-Type-Code kann über die im Rahmen der [KDL-Spezifikation](https://simplifier.net/kdl) publizierten
   [ConceptMaps](https://simplifier.net/kdl/~resources?category=ConceptMap) aus dem KDL-Code ermittelt werden"
@@ -70,9 +73,9 @@ In MHD 4.2.0 wurde die Verpflichtung zur Angabe eines Identifiers gelockert, das
   * ^slicing.discriminator.path = "$this"
   * ^slicing.rules = #open
 * category.coding contains XDS 1..1 MS
-
 * category.coding[XDS] from http://ihe-d.de/ValueSets/IHEXDSclassCode (required)
   * system 1..1 MS
+  * system = "http://ihe-d.de/CodeSystems/IHEXDStypeCode"
     * ^short = "Kodiersystem"
   * code 1..1 MS
     * ^short = "Code"

--- a/Resources/input/fsh/ISiKDokumentenMetadaten.fsh
+++ b/Resources/input/fsh/ISiKDokumentenMetadaten.fsh
@@ -49,6 +49,12 @@ In MHD 4.2.0 wurde die Verpflichtung zur Angabe eines Identifiers gelockert, das
   * ^comment = "Die Übermittlung des XDS-Type-Codes ist im Rahmen der Dokumentenbereitstellung für Clients nicht verpflichtend,
   MUSS jedoch vom Server bei der Entgegennahme ggf. ergänzt und bei der Dokumentenabfrage zurückgegeben werden. Der XDS-Type-Code kann über die im Rahmen der [KDL-Spezifikation](https://simplifier.net/kdl) publizierten
   [ConceptMaps](https://simplifier.net/kdl/~resources?category=ConceptMap) aus dem KDL-Code ermittelt werden"
+  * code 1..1 MS
+    * ^short = "Code"
+    * ^comment = "Der KDL-Code"
+  * display 1..1 MS
+    * ^short = "Anzeigetext"
+    * ^comment = "Der Anzeigetext zum KDL-Code"
 * type.coding[KDL] from http://dvmd.de/fhir/ValueSet/kdl (required)
   * ^short = "Dokumenttyp gem. KDL-Terminologie"
   * system 1..1 MS
@@ -75,7 +81,7 @@ In MHD 4.2.0 wurde die Verpflichtung zur Angabe eines Identifiers gelockert, das
 * category.coding contains XDS 1..1 MS
 * category.coding[XDS] from http://ihe-d.de/ValueSets/IHEXDSclassCode (required)
   * system 1..1 MS
-  * system = "http://ihe-d.de/CodeSystems/IHEXDStypeCode"
+  * system = "http://ihe-d.de/CodeSystems/IHEXDSclassCode"
     * ^short = "Kodiersystem"
   * code 1..1 MS
     * ^short = "Code"


### PR DESCRIPTION
# Contributor Pull Request
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the apposite CodeSystem for XDS type codes as a System in order to enable pattern discrimination
- added Cardinality for code and deiyplay to XDS .type slice
Also added system to .category Slice XDS 


## Motivation and Context
Slice could not be discriminated

## How has this been tested?
compiled locally

## Snippets or Screenshots (if necessary):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this IG / specification.
- [ ] My change requires a change to the documentation or narrative (intend) of the IG. -> not needed
- [ ] I have already updated the documentation / narrative (intend) accordingly. -> not needed